### PR TITLE
Replace depreciated async_setup_platforms

### DIFF
--- a/custom_components/lghorizon/__init__.py
+++ b/custom_components/lghorizon/__init__.py
@@ -53,7 +53,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         API: api,
         CONF_USERNAME: entry.data[CONF_USERNAME],
     }
-    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 


### PR DESCRIPTION
Fix below warning message by using `hass.config_entries.async_forward_entry_setups`

`WARNING (MainThread) [homeassistant.helpers.frame] Detected integration that called async_setup_platforms instead of awaiting async_forward_entry_setups; this will fail in version 2023.3. Please report issue to the custom integration author for lghorizon using this method at custom_components/lghorizon/__init__.py, line 56: hass.config_entries.async_setup_platforms(entry, PLATFORMS)`