### PR TITLE
Replace MediaPlayerState.UNAVAILABLE with STATE.UNAVAILABLE

### DIFF
--- a/custom_components/lghorizon/media_player.py
+++ b/custom_components/lghorizon/media_player.py
@@ -4,6 +4,7 @@ import random
 import datetime as dt
 import time
 import voluptuous as vol
+from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.components.media_player import (
     MediaPlayerEntity,
@@ -159,7 +160,7 @@ class LGHorizonMediaPlayer(MediaPlayerEntity):
             return MediaPlayerState.PLAYING
         if self._box.state == ONLINE_STANDBY:
             return MediaPlayerState.OFF
-        return MediaPlayerState.UNAVAILABLE
+        return STATE_UNAVAILABLE
 
     @property
     def media_content_type(self):


### PR DESCRIPTION
MediaPlayerState.UNAVAILABLE state does not exist in [enum](https://github.com/home-assistant/core/blob/59a01fcf9c42a233ecaa92c6328116128569881c/homeassistant/components/media_player/const.py#L42) hence replacing with STATE.UNAVAILABLE.
