### PR TITLE
Add channel sorting based on config option

### DIFF
--- a/custom_components/lghorizon/config_flow.py
+++ b/custom_components/lghorizon/config_flow.py
@@ -37,6 +37,7 @@ from .const import (
     COUNTRY_CODES,
     CONF_IDENTIFIER,
     CONF_PROFILE_ID,
+    CONF_CHANNEL_SORT
 )
 
 
@@ -157,11 +158,23 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             for profile in self.customer.profiles.values()
         ]
 
+        sort_selectors = [
+            "number",
+            "alpha",
+        ]
+
         profile_schema = vol.Schema(
             {
                 vol.Required(CONF_PROFILE_ID): SelectSelector(
                     SelectSelectorConfig(
                         options=profile_selectors, mode=SelectSelectorMode.DROPDOWN
+                    ),
+                ),
+                vol.Required(CONF_CHANNEL_SORT, default="number"): SelectSelector(
+                    SelectSelectorConfig(
+                        options=sort_selectors,
+                        translation_key="channel_sort",
+                        mode=SelectSelectorMode.DROPDOWN
                     ),
                 ),
             }

--- a/custom_components/lghorizon/const.py
+++ b/custom_components/lghorizon/const.py
@@ -7,6 +7,7 @@ CONF_REFRESH_TOKEN = "refresh_token"
 CONF_REMOTE_KEY = "remote_key"
 CONF_IDENTIFIER = "identifier"
 CONF_PROFILE_ID = "profile_id"
+CONF_CHANNEL_SORT = "channel_sort"
 
 
 RECORD = "record"

--- a/custom_components/lghorizon/manifest.json
+++ b/custom_components/lghorizon/manifest.json
@@ -11,5 +11,5 @@
   "requirements": [
     "lghorizon>=0.8.6"
   ],
-  "version": "0.7.8"
+  "version": "0.7.9"
 }

--- a/custom_components/lghorizon/media_player.py
+++ b/custom_components/lghorizon/media_player.py
@@ -41,6 +41,7 @@ from .const import (
     REWIND,
     FAST_FORWARD,
     CONF_REMOTE_KEY,
+    CONF_CHANNEL_SORT,
     REMOTE_KEY_PRESS,
 )
 
@@ -260,10 +261,13 @@ class LGHorizonMediaPlayer(MediaPlayerEntity):
     @property
     def source_list(self):
         """Return a list with available sources."""
-        channel_list = []
-        for channel in self.api.get_display_channels():
-            channel_list.append(channel.title)
-        return channel_list
+        sort_mode = self.entry.data.get(CONF_CHANNEL_SORT, "number")
+        channels = self.api.get_display_channels() or []
+        if sort_mode == "number":
+            sorted_channels = sorted(channels, key=lambda ch: int(ch.channel_number))
+        else:
+            sorted_channels = sorted(channels, key=lambda ch: ch.title.lower())
+        return [ch.title for ch in sorted_channels]
 
     @property
     def media_duration(self) -> int | None:

--- a/custom_components/lghorizon/translations/en.json
+++ b/custom_components/lghorizon/translations/en.json
@@ -24,7 +24,9 @@
         "description": "Select your profile to show it's favorite channels only",
         "data": {
           "profile_id": "Profile",
-          "channel_sort": "Channel sort order"
+          "channel_sort": "Channel sort order",          
+          "channel_sort_alpha": "Alphabetical",          
+          "channel_sort_number": "Channel number"
         }
       }
     },
@@ -36,6 +38,14 @@
     },
     "abort": {
       "already_configured": "This account is already configured."
+    }
+  },
+  "selector": {
+    "channel_sort": {
+      "options": {
+        "alpha": "Alfabetical",
+        "number": "Channel number"
+      }
     }
   },
   "services": {

--- a/custom_components/lghorizon/translations/en.json
+++ b/custom_components/lghorizon/translations/en.json
@@ -23,7 +23,8 @@
         "title": "LG Horizon - Select profile",
         "description": "Select your profile to show it's favorite channels only",
         "data": {
-          "profile_id": "Profile"
+          "profile_id": "Profile",
+          "channel_sort": "Channel sort order"
         }
       }
     },

--- a/custom_components/lghorizon/translations/nl.json
+++ b/custom_components/lghorizon/translations/nl.json
@@ -24,7 +24,9 @@
         "description": "Selecteer het profiel waarvan je de favoriete kanalen wilt tonen",
         "data": {
           "profile_id": "Profiel",          
-          "channel_sort": "Kanaalvolgorde"
+          "channel_sort": "Kanaalvolgorde",       
+          "channel_sort_alpha": "Alfabetisch",          
+          "channel_sort_number": "Kanaalnummer"
         }
       }
     },
@@ -36,6 +38,14 @@
     },
     "abort": {
       "already_configured": "Dit account is reeds toegevoegd."
+    }
+  },
+  "selector": {
+    "channel_sort": {
+      "options": {
+        "alpha": "Alfabetisch",
+        "number": "Kanaalnummer"
+      }
     }
   },
   "services": {

--- a/custom_components/lghorizon/translations/nl.json
+++ b/custom_components/lghorizon/translations/nl.json
@@ -23,7 +23,8 @@
         "title": "LG Horizon - Selecteer profiel",
         "description": "Selecteer het profiel waarvan je de favoriete kanalen wilt tonen",
         "data": {
-          "profile_id": "Profiel"
+          "profile_id": "Profiel",          
+          "channel_sort": "Kanaalvolgorde"
         }
       }
     },


### PR DESCRIPTION
In the config flow, you now have the option to select the channel sort order.

- Alphabetically from A-Z
- Respecting the channel number from the provider