### PR TITLE
Add planned recordings to browse media, fix SEASON/SHOW bug

### DIFF
--- a/custom_components/lghorizon/media_player.py
+++ b/custom_components/lghorizon/media_player.py
@@ -30,6 +30,7 @@ from lghorizon import (
     LGHorizonEpg,
     LGHorizonEpgEvent,
     LGHorizonEventDetail,
+    LGHorizonManagedRecordingList,
     LGHorizonRecording,
     LGHorizonRecordingList,
     LGHorizonRecordingSeason,
@@ -597,11 +598,49 @@ class LGHorizonMediaPlayer(MediaPlayerEntity):
     async def async_browse_media(self, media_content_type=None, media_content_id=None):
         """Support browsing media."""
         if media_content_type in [None, "main"]:
-            main = BrowseMedia(
-                title="Opnames",
+            root = BrowseMedia(
+                title="Media",
                 media_class=MediaClass.DIRECTORY,
                 media_content_type="main",
                 media_content_id="main",
+                can_play=False,
+                can_expand=True,
+                children=[],
+                children_media_class=MediaClass.DIRECTORY,
+            )
+            # Folder: Opnames (recorded)
+            root.children.append(
+                BrowseMedia(
+                    title="Opnames",
+                    media_class=MediaClass.DIRECTORY,
+                    media_content_type="recordings",
+                    media_content_id="recordings",
+                    can_play=False,
+                    can_expand=True,
+                    children=[],
+                    children_media_class=MediaClass.DIRECTORY,
+                )
+            )
+            # Folder: Gepland (planned/scheduled)
+            root.children.append(
+                BrowseMedia(
+                    title="Gepland",
+                    media_class=MediaClass.DIRECTORY,
+                    media_content_type="planned",
+                    media_content_id="planned",
+                    can_play=False,
+                    can_expand=True,
+                    children=[],
+                    children_media_class=MediaClass.DIRECTORY,
+                )
+            )
+            return root
+        if media_content_type == "recordings":
+            main = BrowseMedia(
+                title="Opnames",
+                media_class=MediaClass.DIRECTORY,
+                media_content_type="recordings",
+                media_content_id="recordings",
                 can_play=False,
                 can_expand=True,
                 children=[],
@@ -628,7 +667,7 @@ class LGHorizonMediaPlayer(MediaPlayerEntity):
                             children_media_class=MediaClass.DIRECTORY,
                         )
                         main.children.append(show_media)
-                    case LGHorizonRecordingType.SEASON:
+                    case LGHorizonRecordingType.SHOW:
                         recording.__class__ = LGHorizonRecordingShow
                         show_recording = cast(LGHorizonRecordingShow, recording)
                         show_media = BrowseMedia(
@@ -657,6 +696,49 @@ class LGHorizonMediaPlayer(MediaPlayerEntity):
                         )
                         main.children.append(show_media)
             return main
+        if media_content_type == "planned":
+            planned = BrowseMedia(
+                title="Gepland",
+                media_class=MediaClass.DIRECTORY,
+                media_content_type="planned",
+                media_content_id="planned",
+                can_play=False,
+                can_expand=True,
+                children=[],
+                children_media_class=MediaClass.DIRECTORY,
+            )
+            try:
+                managed_list: LGHorizonManagedRecordingList = (
+                    await self.api.get_managed_recordings()
+                )
+                for rec in managed_list.recordings:
+                    if rec.recording_state not in ("planned", "partiallyRecorded"):
+                        continue
+                    title_parts = []
+                    if rec.show_name:
+                        title_parts.append(rec.show_name)
+                    if rec.season_number is not None and rec.episode_number is not None:
+                        title_parts.append(
+                            f"S{str(rec.season_number).zfill(2)}E{str(rec.episode_number).zfill(2)}"
+                        )
+                    if rec.title and rec.title != rec.show_name:
+                        title_parts.append(rec.title)
+                    display_title = " - ".join(title_parts) if title_parts else rec.title
+                    if rec.recording_state == "partiallyRecorded":
+                        display_title = f"⏺ {display_title}"
+                    planned.children.append(
+                        BrowseMedia(
+                            title=display_title,
+                            media_class=MediaClass.EPISODE,
+                            media_content_type=MediaType.EPISODE,
+                            media_content_id=rec.id,
+                            can_play=False,
+                            can_expand=False,
+                        )
+                    )
+            except Exception:
+                _LOGGER.warning("Failed to fetch planned recordings", exc_info=True)
+            return planned
         if media_content_type == MediaType.TVSHOW:
             show_id, channel_id = media_content_id.split("|", 1)
             show_recordings_list: LGHorizonShowRecordingList = (


### PR DESCRIPTION
- Restructure browse_media: root with 'Opnames' and 'Gepland' folders
- Add planned recordings via get_managed_recordings API
- Fix duplicate SEASON match arm (second should be SHOW)
- Existing recordings keep thumbnails via get_all_recordings